### PR TITLE
Fix an issue with NPCs with missing sense data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3 - 2022-05-06
+- Fix an issue with NPCs with missing sense data
+
 ## 1.0.2 - 2022-02-28
 - Change wall inclusion overrides to high-performance mode
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "Sense Walls",
     "description": "Enable walls only for tokens without a certain vision level.",
     "author": "JDCalvert",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-Sense-Walls",
     "manifest": "https://github.com/JDCalvert/FVTT-Sense-Walls/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-Sense-Walls/archive/1.0.2.zip",
+    "download": "https://github.com/JDCalvert/FVTT-Sense-Walls/archive/1.0.3.zip",
     "readme": "https://github.com/JDCalvert/FVTT-Sense-Walls",
     "bugs": "https://github.com/JDCalvert/FVTT-Sense-Walls/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-Sense-Walls/blob/main/CHANGELOG.md",

--- a/scripts/sensewalls.js
+++ b/scripts/sensewalls.js
@@ -51,7 +51,7 @@ function updateVisionLevel(token) {
     if (actor.type === "npc") {
         //NPCs have one "sense" which is a free-text entry. Try to find the individual senses from there
         //by splitting on comma characters and removing whitespace and the dash in "low-light vision"
-        senses = senses.value.split(",").map(s => s.replace(/[\s-]+/g, '').toLowerCase());
+        senses = (senses.value ?? "").split(",").map(s => s.replace(/[\s-]+/g, '').toLowerCase());
     } else if (actor.type == "character" || actor.type == "familiar") {
         //Characters have an array of senses. Just put them to lower case to make matching easier
         senses = senses.map(sense => sense.type.toLowerCase());


### PR DESCRIPTION
Fixed an issue where an NPCs sense value being `undefined` would cause an error preventing the canvas from rendering.